### PR TITLE
Levels and LevelManager now have a function to reset levelUpgrades.

### DIFF
--- a/include/Level.h
+++ b/include/Level.h
@@ -51,6 +51,7 @@ public:
 	void									SetUpgradeLevel(LEVELS::UPGRADE upgrade); // Only used for loading
 	void									ActivateChests(); //Turns on the relevant chests for upgrade level and also adds them as observers;
 	void									DeactiveChests();
+	void									ResetLevelUpgrades();
 
 private:
 	LEVELS::LEVEL							mLevelID;

--- a/include/LevelManager.h
+++ b/include/LevelManager.h
@@ -14,6 +14,7 @@ public:
 	Level& GetNextLevel();
 	void	SaveLevels();
 	void	LoadLevels();
+	void	ResetLevelUpgrades();
 
 
 

--- a/src/AssetManager.cpp
+++ b/src/AssetManager.cpp
@@ -634,7 +634,7 @@ sf::Color AssetManager::GetColorForItemText(std::pair<ITEMID::ITEM, ITEMRARITY::
     }
     switch (item.second)
     {
-    case ITEMRARITY::NORMAL:	    return sf::Color::White;
+    case ITEMRARITY::NORMAL:	    return sf::Color::White;            break;
     case ITEMRARITY::MAGIC:		    return sf::Color{  51, 102, 255 };	break;
     case ITEMRARITY::RARE:		    return sf::Color{ 253, 216, 53 };	break;
     case ITEMRARITY::SET:		    return sf::Color{ 44 , 190, 52 };	break;

--- a/src/Level.cpp
+++ b/src/Level.cpp
@@ -340,3 +340,8 @@ void Level::DeactiveChests()
 		chest->SetActive(false);
 	}
 }
+
+void Level::ResetLevelUpgrades()
+{
+	mUpgradeLevel = LEVELS::UPGRADE::ONE_CHEST;
+}

--- a/src/LevelManager.cpp
+++ b/src/LevelManager.cpp
@@ -130,3 +130,11 @@ void LevelManager::LoadLevels()
 		}
 	}
 }
+
+void LevelManager::ResetLevelUpgrades()
+{
+	for (auto& level : mLevels)
+	{
+		level->ResetLevelUpgrades();
+	}
+}


### PR DESCRIPTION
Call LevelManager::ResetLevelUpgrades to reset them all.